### PR TITLE
docs: update authors section with contributor images

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,23 @@ tsconfig.json
 
 ## Auteurs
 
-- **Yassine ANZAR BASHA**
-- **Abubakar ALIEV**
-- **Quentin DOULCET**
-- **Guillaume EAP**
+Merci à tous les contributeurs de ce projet :
+
+<p>
+   <a href="https://github.com/TheYassAnz" target="_blank">
+      <img src="https://github.com/TheYassAnz.png"  alt="Yassine ANZAR BASHA" style="border-radius: 50%; width: 50px; height: 50px;">
+   </a>
+   <a href="https://github.com/AbubakarAliev" target="_blank">
+      <img src="https://github.com/AbubakarAliev.png" alt="Abubakar ALIEV" style="border-radius: 50%; width: 50px; height: 50px;">
+   </a>
+   <a href="https://github.com/Maneldj" target="_blank">
+      <img src="https://github.com/Maneldj.png" alt="Manel DJEDIR" style="border-radius: 50%; width: 50px; height: 50px;">
+   </a>
+   <a href="https://github.com/NutNak" target="_blank">
+      <img src="https://github.com/NutNak.png" alt="Quentin DOULCET" style="border-radius: 50%; width: 50px; height: 50px;">
+   </a>
+   <a href="https://github.com/geap1999" target="_blank">
+      <img src="https://github.com/geap1999.png" alt="Guillaume EAP" style="border-radius: 50%; width: 50px; height: 50px;">
+   </a>
+   
+</p>


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the authors section to include clickable profile images for each contributor. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R86): Replaced text-based author names with clickable profile images linking to each contributor's GitHub profile.