### PR TITLE
feat: add data sanitization middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcryptjs": "^3.0.2",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-mongo-sanitize": "^2.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.14.2",
         "mongoose": "^8.12.1",
@@ -4706,6 +4707,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/extract-zip": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bcryptjs": "^3.0.2",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-mongo-sanitize": "^2.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.14.2",
     "mongoose": "^8.12.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Application, Request, Response } from "express";
 import dotenv from "dotenv";
 dotenv.config();
 import mongoose from "mongoose";
+import mongoSanitize from "express-mongo-sanitize";
 
 const clientOptions = {
   serverApi: { version: "1" as const, strict: true, deprecationErrors: true },
@@ -19,7 +20,7 @@ mongoose
 const app: Application = express();
 
 app.use(express.json());
-app.use(express.json());
+app.use(mongoSanitize());
 
 app.get("/", (req: Request, res: Response) => {
   res.json({ message: "Hello World!" });


### PR DESCRIPTION
Même s'il y a une protection dans le front contre les injections, il en faut aussi dans le back car une personne malveillante peut envoyer des requêtes POST/PUT sans passer par le front avec un token valide dans le header (via cURL par exemple). Ce middleware va permettre de ne pas enregistrer de données s'il y a présence de caractères spéciaux utilisés dans les injections.

On peut aussi remplacer ces caractères avec des caractères valides et enregistrer les données, à vous de voir.

Lien middleware: https://www.npmjs.com/package/express-mongo-sanitize