### PR TITLE
Refacto create refund

### DIFF
--- a/src/controllers/accommodation.ts
+++ b/src/controllers/accommodation.ts
@@ -11,7 +11,7 @@ const getAllAccommodations = async (
     return res.status(200).json({ message: "Ok", data: accommodations });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -52,7 +52,7 @@ const register = async (req: Request, res: Response): Promise<any> => {
     if (error.name === "ValidationError") {
       return res.status(400).json({ message: "Bad request" });
     }
-    res.status(500).json({ message: "Internal server error." });
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -83,7 +83,7 @@ const login = async (req: Request, res: Response) => {
     const token = jwt.sign({ id: user._id }, secretKey, { expiresIn: "1h" });
     res.status(200).json({ message: "OK", data: token });
   } catch (error: any) {
-    res.status(500).json({ message: "Internal server error." });
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 

--- a/src/controllers/event.ts
+++ b/src/controllers/event.ts
@@ -21,7 +21,7 @@ const getAllEvents = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: events });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -53,7 +53,7 @@ const createEvent = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -75,7 +75,7 @@ const getEventById = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: event });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -104,7 +104,7 @@ const updateEventById = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -126,7 +126,7 @@ const deleteEventById = async (req: Request, res: Response): Promise<any> => {
     return res.sendStatus(204);
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -160,7 +160,7 @@ const filterEvents = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: events });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/controllers/file.ts
+++ b/src/controllers/file.ts
@@ -80,7 +80,7 @@ const uploadFile = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -103,7 +103,7 @@ const getFileById = async (req: Request, res: Response): Promise<any> => {
     res.sendFile(filePath);
   } catch (error: any) {
     res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -129,7 +129,7 @@ const deleteFileById = async (req: Request, res: Response): Promise<any> => {
     return res.sendStatus(204);
   } catch (error: any) {
     res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/controllers/rule.ts
+++ b/src/controllers/rule.ts
@@ -8,7 +8,7 @@ const getAllRules = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: rules });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -30,7 +30,7 @@ const createRule = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -52,7 +52,7 @@ const getRuleById = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: rule });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -81,7 +81,7 @@ const updateRuleById = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -103,7 +103,7 @@ const deleteRuleById = async (req: Request, res: Response): Promise<any> => {
     return res.sendStatus(204);
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -18,7 +18,7 @@ const getAllTasks = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: tasks });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -44,7 +44,7 @@ const createTask = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -66,7 +66,7 @@ const getTaskById = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: task });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -95,7 +95,7 @@ const updateTaskById = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -117,7 +117,7 @@ const deleteTaskById = async (req: Request, res: Response): Promise<any> => {
     return res.sendStatus(204);
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };
@@ -149,7 +149,7 @@ const filterTasks = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: events });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -16,7 +16,7 @@ const getAllUsers = async (req: Request, res: Response): Promise<any> => {
     const users = await User.find();
     return res.json({ message: "Ok", data: users });
   } catch (error) {
-    return res.status(500).json({ message: "Internal server error." });
+    return res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -35,7 +35,7 @@ const getUserById = async (req: Request, res: Response): Promise<any> => {
 
     return res.status(200).json({ message: "Ok", data: user });
   } catch (error: any) {
-    return res.status(500).json({ message: "Internal server error." });
+    return res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -68,7 +68,7 @@ const updateUserById = async (req: Request, res: Response): Promise<any> => {
     if (error.name === "ValidationError") {
       return res.status(400).json({ message: "Bad request" });
     }
-    return res.status(500).json({ message: "Internal server error." });
+    return res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -84,7 +84,7 @@ const deleteUserById = async (req: Request, res: Response): Promise<any> => {
 
     return res.sendStatus(204);
   } catch (error: any) {
-    return res.status(500).json({ message: "Internal server error." });
+    return res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -108,7 +108,7 @@ const filterUsers = async (req: Request, res: Response): Promise<any> => {
     return res.status(200).json({ message: "Ok", data: users });
   } catch (error: any) {
     return res.status(500).json({
-      message: "Internal server error.",
+      message: "Internal server error",
     });
   }
 };

--- a/src/routes/refund.ts
+++ b/src/routes/refund.ts
@@ -5,7 +5,7 @@ const router = express.Router();
 
 router.get("/", refundCtrl.getAllRefunds);
 router.get("/filter", refundCtrl.filterRefunds);
-router.post("/", refundCtrl.createRefund);
+router.post("/", refundCtrl.createRefunds);
 router.get("/:id", refundCtrl.getRefundById);
 router.put("/:id", refundCtrl.updateRefundById);
 router.delete("/:id", refundCtrl.deleteRefundById);

--- a/src/test/integration/refund.test.ts
+++ b/src/test/integration/refund.test.ts
@@ -14,9 +14,9 @@ describe("Refund API Integration Tests", () => {
   test("POST /refunds should create a new refund", async () => {
     const refundData = {
       title: "Test Refund",
-      to_refund: 100,
+      to_split: 200,
       user_id: "67ecf50fe1ec65f57a487989",
-      roomate_id: "67e922f5f031d41cd1da4fe4",
+      roomate_ids: ["67e922f5f031d41cd1da4fe4"],
     };
 
     const response = await request(app)
@@ -25,16 +25,16 @@ describe("Refund API Integration Tests", () => {
       .expect(201);
 
     expect(response.body).toHaveProperty("message", "Ok");
-    expect(response.body.data).toHaveProperty("title", "Test Refund");
-    refundId = response.body.data._id;
+    expect(response.body.data[0]).toHaveProperty("title", "Test Refund");
+    refundId = response.body.data[0]._id;
   });
 
   test("POST /refunds should return 400 for invalid data", async () => {
     const invalidRefundData = {
       title: "",
-      to_refund: -100,
+      to_split: -100,
       user_id: "",
-      roomate_id: "",
+      roomate_ids: [],
     };
 
     const response = await request(app)

--- a/src/test/unit/refund.test.ts
+++ b/src/test/unit/refund.test.ts
@@ -1,0 +1,5 @@
+import { splitRefund } from "../../controllers/refund";
+
+test("split refund", () => {
+  expect(splitRefund(60, 2)).toBe(20);
+});


### PR DESCRIPTION
La création d'un seul refund ne se fait plus directement via le endpoint post "/refunds". Maintenant ce endpoint gère la création d'un ou plusieurs refunds et renvoie un objet data sous forme d'array. Il prend donc en paramètre un array de colocataires et un montant à partager par le user et ses colocataires. 

Ceci a été conseillé par Nicolas afin d'avoir un composant métier (toSplit) et d'avoir un cas de test unitaire. 