### PR TITLE
Feature/add xss protection middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-mongo-sanitize": "^2.2.0",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.14.2",
         "mongoose": "^8.12.1",
-        "multer": "^1.4.5-lts.2"
+        "multer": "^1.4.5-lts.2",
+        "sanitize-html": "^2.16.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
@@ -27,6 +29,7 @@
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.13.10",
+        "@types/sanitize-html": "^2.15.0",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.23.0",
         "esm": "^3.2.25",
@@ -2499,6 +2502,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.15.0.tgz",
+      "integrity": "sha512-71Z6PbYsVKfp4i6Jvr37s5ql6if1Q/iJQT80NbaSi7uGaG8CqBMXP0pk/EsURAOuGdk5IJCd/vnzKrR7S3Txsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
+    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -3980,7 +3993,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4078,6 +4090,61 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-prop": {
@@ -4194,6 +4261,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -5412,6 +5491,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/hexoid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
@@ -5428,6 +5516,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5781,6 +5888,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -7282,6 +7398,24 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7568,6 +7702,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7631,7 +7771,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7668,6 +7807,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -8164,6 +8331,32 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-0s4caLuHHaZFVxFTG74oW91+j6vW7gKbGD6CD2+miP73CE6z6YtOBN0ArtLd2UGyi4IC7K47v3ENUbQX4jV3Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8430,6 +8623,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.13.10",
+    "@types/sanitize-html": "^2.15.0",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.23.0",
     "esm": "^3.2.25",
@@ -39,10 +40,12 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-mongo-sanitize": "^2.2.0",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.14.2",
     "mongoose": "^8.12.1",
-    "multer": "^1.4.5-lts.2"
+    "multer": "^1.4.5-lts.2",
+    "sanitize-html": "^2.16.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import dotenv from "dotenv";
 dotenv.config();
 import mongoose from "mongoose";
 import mongoSanitize from "express-mongo-sanitize";
+import { xssSanitizer } from "./middleware/xssSanitizer";
+import helmet from "helmet";
 
 const clientOptions = {
   serverApi: { version: "1" as const, strict: true, deprecationErrors: true },
@@ -20,7 +22,9 @@ mongoose
 const app: Application = express();
 
 app.use(express.json());
-app.use(mongoSanitize());
+app.use(mongoSanitize()); // Protect against NoSQL injection
+app.use(xssSanitizer); // Sanitize user inputs to prevent XSS
+app.use(helmet()); // Set security headers to protect the frontend from XSS
 
 app.get("/", (req: Request, res: Response) => {
   res.json({ message: "Hello World!" });

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -6,16 +6,16 @@ import jwt from "jsonwebtoken";
 const register = async (req: Request, res: Response): Promise<any> => {
   try {
     const {
-      firstname,
-      lastname,
+      firstName,
+      lastName,
       username,
       password,
       age,
       description,
       email,
-      phone_number,
-      profile_picture_id,
-      accommodation_id,
+      phoneNumber,
+      profilePictureId,
+      accommodationId,
     } = req.body;
 
     const existUsername = await User.findOne({ username });
@@ -33,16 +33,16 @@ const register = async (req: Request, res: Response): Promise<any> => {
     const hashedPassword = await bcrypt.hash(password, 10);
 
     const newUser = new User({
-      firstname,
-      lastname,
+      firstName,
+      lastName,
       username,
       password: hashedPassword,
       age,
       description,
       email,
-      phone_number,
-      profile_picture_id,
-      accommodation_id,
+      phoneNumber,
+      profilePictureId,
+      accommodationId,
     });
 
     await newUser.save();

--- a/src/controllers/event.ts
+++ b/src/controllers/event.ts
@@ -7,12 +7,12 @@ interface QueryParamsEvents {
     $regex: string;
     $options: string;
   };
-  planned_date?: {
+  plannedDate?: {
     $gte?: Date;
     $lte?: Date;
   };
-  end_date?: Date;
-  user_id?: string;
+  endDate?: Date;
+  userId?: string;
 }
 
 const getAllEvents = async (req: Request, res: Response): Promise<any> => {
@@ -31,19 +31,19 @@ const createEvent = async (req: Request, res: Response): Promise<any> => {
     const {
       title,
       description,
-      planned_date,
-      end_date,
-      user_id,
-      accommodation_id,
+      plannedDate,
+      endDate,
+      userId,
+      accommodationId,
     } = req.body;
 
     const newEvent = new Event({
       title,
       description,
-      planned_date: new Date(planned_date),
-      end_date: new Date(end_date),
-      user_id,
-      accommodation_id,
+      plannedDate: new Date(plannedDate),
+      endDate: new Date(endDate),
+      userId,
+      accommodationId,
     });
 
     await newEvent.save();
@@ -133,7 +133,7 @@ const deleteEventById = async (req: Request, res: Response): Promise<any> => {
 
 const filterEvents = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { title, planned_date_start, planned_date_end, user_id } = req.query;
+    const { title, plannedDateStart, plannedDateEnd, userId } = req.query;
 
     const params: QueryParamsEvents = {};
 
@@ -141,18 +141,18 @@ const filterEvents = async (req: Request, res: Response): Promise<any> => {
       params.title = { $regex: title as string, $options: "i" };
     }
 
-    if (planned_date_start || planned_date_end) {
-      params.planned_date = {};
-      if (planned_date_start) {
-        params.planned_date.$gte = new Date(planned_date_start as string);
+    if (plannedDateStart || plannedDateEnd) {
+      params.plannedDate = {};
+      if (plannedDateStart) {
+        params.plannedDate.$gte = new Date(plannedDateStart as string);
       }
-      if (planned_date_end) {
-        params.planned_date.$lte = new Date(planned_date_end as string);
+      if (plannedDateEnd) {
+        params.plannedDate.$lte = new Date(plannedDateEnd as string);
       }
     }
 
-    if (user_id) {
-      params.user_id = user_id as string;
+    if (userId) {
+      params.userId = userId as string;
     }
 
     const events = await Event.find(params);

--- a/src/controllers/file.ts
+++ b/src/controllers/file.ts
@@ -59,7 +59,7 @@ const uploadFile = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "No file uploaded." });
     }
 
-    const { description, user_id } = req.body;
+    const { description, userId } = req.body;
 
     const fileType =
       req.file.mimetype === "application/pdf" ? FileTypes.PDF : FileTypes.IMAGE;
@@ -70,7 +70,7 @@ const uploadFile = async (req: Request, res: Response): Promise<any> => {
       description,
       type: fileType,
       size: req.file.size,
-      user_id,
+      userId,
     });
 
     await newFile.save();

--- a/src/controllers/refund.ts
+++ b/src/controllers/refund.ts
@@ -7,11 +7,11 @@ interface QueryParamsRefunds {
     $regex: string;
     $options: string;
   };
-  to_refund?: {
+  toRefund?: {
     $gte?: number;
     $lte?: number;
   };
-  roommate_id?: string;
+  roomateId?: string;
 }
 
 const getAllRefunds = async (req: Request, res: Response): Promise<any> => {
@@ -23,18 +23,18 @@ const getAllRefunds = async (req: Request, res: Response): Promise<any> => {
   }
 };
 
-export const splitRefund = (to_split: number, roommates: number): number => {
-  return parseFloat((to_split / (roommates + 1)).toFixed(2));
+export const splitRefund = (toSplit: number, roomates: number): number => {
+  return parseFloat((toSplit / (roomates + 1)).toFixed(2));
 };
 
 const createRefund = async (
   title: string,
-  to_refund: number,
-  user_id: string,
-  roommate_id: string,
+  toRefund: number,
+  userId: string,
+  roomateId: string,
 ): Promise<any> => {
   try {
-    const newRefund = new Refund({ title, to_refund, user_id, roommate_id });
+    const newRefund = new Refund({ title, toRefund, userId, roomateId });
 
     await newRefund.save();
 
@@ -49,21 +49,21 @@ const createRefund = async (
 
 const createRefunds = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { title, to_split, user_id, roommate_ids } = req.body; // roommate_ids is a string[]
+    const { title, toSplit, userId, roomateIds } = req.body; // roomateIds is a string[]
 
-    if (to_split < 0) {
+    if (toSplit < 0) {
       return res.status(400).json({ message: "Bad request" });
     }
 
-    if (roommate_ids.length === 0) {
+    if (roomateIds.length === 0) {
       return res.status(400).json({ message: "Bad request" });
     }
 
-    const to_refund = splitRefund(to_split, roommate_ids.length);
+    const toRefund = splitRefund(toSplit, roomateIds.length);
 
     const newRefunds = await Promise.all(
-      roommate_ids.map(async (roommate_id: string) => {
-        return await createRefund(title, to_refund, user_id, roommate_id);
+      roomateIds.map(async (roomateId: string) => {
+        return await createRefund(title, toRefund, userId, roomateId);
       }),
     );
 
@@ -104,9 +104,9 @@ const updateRefundById = async (req: Request, res: Response): Promise<any> => {
       return res.status(400).json({ message: "Bad request" });
     }
 
-    const to_refund = req.body.to_refund;
+    const toRefund = req.body.toRefund;
 
-    if (to_refund && to_refund < 0) {
+    if (toRefund && toRefund < 0) {
       return res.status(400).json({ message: "Bad request" });
     }
 
@@ -154,7 +154,7 @@ const deleteRefundById = async (req: Request, res: Response): Promise<any> => {
 
 const filterRefunds = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { title, to_refund_start, to_refund_end, roommate_id } = req.query;
+    const { title, toRefundStart, toRefundEnd, roomateId } = req.query;
 
     const params: QueryParamsRefunds = {};
 
@@ -162,18 +162,18 @@ const filterRefunds = async (req: Request, res: Response): Promise<any> => {
       params.title = { $regex: title as string, $options: "i" };
     }
 
-    if (to_refund_start || to_refund_end) {
-      params.to_refund = {};
-      if (to_refund_start) {
-        params.to_refund.$gte = Number(to_refund_start as string);
+    if (toRefundStart || toRefundEnd) {
+      params.toRefund = {};
+      if (toRefundStart) {
+        params.toRefund.$gte = Number(toRefundStart as string);
       }
-      if (to_refund_end) {
-        params.to_refund.$lte = Number(to_refund_end as string);
+      if (toRefundEnd) {
+        params.toRefund.$lte = Number(toRefundEnd as string);
       }
     }
 
-    if (roommate_id) {
-      params.roommate_id = roommate_id as string;
+    if (roomateId) {
+      params.roomateId = roomateId as string;
     }
 
     const refunds = await Refund.find(params);

--- a/src/controllers/rule.ts
+++ b/src/controllers/rule.ts
@@ -15,12 +15,12 @@ const getAllRules = async (req: Request, res: Response): Promise<any> => {
 
 const createRule = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { title, description, accommodation_id } = req.body;
+    const { title, description, accommodationId } = req.body;
 
     const newRule = new Rule({
       title,
       description,
-      accommodation_id,
+      accommodationId,
     });
 
     await newRule.save();

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -9,7 +9,7 @@ interface QueryParamsTasks {
   };
   weekly?: boolean;
   done?: boolean;
-  user_id?: string;
+  userId?: string;
 }
 
 const getAllTasks = async (req: Request, res: Response): Promise<any> => {
@@ -25,7 +25,7 @@ const getAllTasks = async (req: Request, res: Response): Promise<any> => {
 
 const createTask = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { name, description, weekly, done, user_id, accommodation_id } =
+    const { name, description, weekly, done, userId, accommodationId } =
       req.body;
 
     const newTask = new Task({
@@ -33,8 +33,8 @@ const createTask = async (req: Request, res: Response): Promise<any> => {
       description,
       weekly,
       done,
-      user_id,
-      accommodation_id,
+      userId,
+      accommodationId,
     });
 
     await newTask.save();
@@ -124,7 +124,7 @@ const deleteTaskById = async (req: Request, res: Response): Promise<any> => {
 
 const filterTasks = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { name, weekly, done, user_id } = req.query;
+    const { name, weekly, done, userId } = req.query;
 
     const params: QueryParamsTasks = {};
 
@@ -140,8 +140,8 @@ const filterTasks = async (req: Request, res: Response): Promise<any> => {
       params.done = done === "true";
     }
 
-    if (user_id) {
-      params.user_id = user_id as string;
+    if (userId) {
+      params.userId = userId as string;
     }
 
     const events = await Task.find(params);

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -32,7 +32,6 @@ const createTask = async (req: Request, res: Response): Promise<any> => {
       name,
       description,
       weekly,
-      done,
       userId,
       accommodationId,
     });

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -5,8 +5,8 @@ import mongoose from "mongoose";
 
 interface QueryParamsUsers {
   $or?: {
-    firstname?: { $regex: string; $options: string };
-    lastname?: { $regex: string; $options: string };
+    firstName?: { $regex: string; $options: string };
+    lastName?: { $regex: string; $options: string };
     username?: { $regex: string; $options: string };
   }[];
 }
@@ -15,7 +15,7 @@ const getAllUsers = async (req: Request, res: Response): Promise<any> => {
   try {
     const users = await User.find();
     return res.json({ message: "Ok", data: users });
-  } catch (error) {
+  } catch (error: any) {
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -97,8 +97,8 @@ const filterUsers = async (req: Request, res: Response): Promise<any> => {
     if (name) {
       const regex = { $regex: name as string, $options: "i" };
       params.$or = [
-        { firstname: regex },
-        { lastname: regex },
+        { firstName: regex },
+        { lastName: regex },
         { username: regex },
       ];
     }

--- a/src/middleware/xssSanitizer.ts
+++ b/src/middleware/xssSanitizer.ts
@@ -1,0 +1,35 @@
+import sanitizeHtml from "sanitize-html";
+import { Request, Response, NextFunction } from "express";
+
+export const xssSanitizer = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const sanitize = (value: any) => {
+    if (typeof value === "string") {
+      return sanitizeHtml(value);
+    }
+    return value;
+  };
+
+  if (req.body) {
+    for (const key in req.body) {
+      req.body[key] = sanitize(req.body[key]);
+    }
+  }
+
+  if (req.query) {
+    for (const key in req.query) {
+      req.query[key] = sanitize(req.query[key]);
+    }
+  }
+
+  if (req.params) {
+    for (const key in req.params) {
+      req.params[key] = sanitize(req.params[key]);
+    }
+  }
+
+  next();
+};

--- a/src/models/accommodation.ts
+++ b/src/models/accommodation.ts
@@ -8,14 +8,20 @@ interface Accommodation extends Document {
   country: string;
 }
 
-const accommodationSchema = new Schema<Accommodation>({
-  name: { type: String, required: true },
-  code: { type: String, required: true, unique: true },
-  location: { type: String, required: true },
-  postalCode: { type: Number, required: true },
-  country: { type: String, required: true },
-});
+const accommodationSchema = new Schema<Accommodation>(
+  {
+    name: { type: String, required: true },
+    code: { type: String, required: true, unique: true },
+    location: { type: String, required: true },
+    postalCode: { type: Number, required: true },
+    country: { type: String, required: true },
+  },
+  { timestamps: true },
+);
 
-const AccommodationModel = model<Accommodation>("Accommodation", accommodationSchema);
+const AccommodationModel = model<Accommodation>(
+  "Accommodation",
+  accommodationSchema,
+);
 
 export default AccommodationModel;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -2,25 +2,28 @@ import { Schema, model, Types, Document } from "mongoose";
 
 interface Event extends Document {
   title: string;
-  description: string | null;
-  planned_date: Date;
-  end_date: Date;
-  user_id: Types.ObjectId;
-  accommodation_id: Types.ObjectId;
+  description: string;
+  plannedDate: Date;
+  endDate: Date;
+  userId: Types.ObjectId;
+  accommodationId: Types.ObjectId;
 }
 
-const eventSchema = new Schema<Event>({
-  title: { type: String, required: true, maxLength: 50 },
-  description: { type: String, required: false, default: null },
-  planned_date: { type: Date, required: true },
-  end_date: { type: Date, required: true },
-  user_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
-  accommodation_id: {
-    type: Schema.Types.ObjectId,
-    ref: "Accommodation",
-    required: true,
+const eventSchema = new Schema<Event>(
+  {
+    title: { type: String, required: true, maxLength: 50 },
+    description: { type: String, required: false, default: null },
+    plannedDate: { type: Date, required: true },
+    endDate: { type: Date, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    accommodationId: {
+      type: Schema.Types.ObjectId,
+      ref: "Accommodation",
+      required: true,
+    },
   },
-});
+  { timestamps: true },
+);
 
 const EventModel = model<Event>("Event", eventSchema);
 

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -11,17 +11,21 @@ interface File extends Document {
   description: string | null;
   type: FileTypes;
   size: number;
-  user_id: Types.ObjectId;
+  userId: Types.ObjectId;
 }
 
-const fileSchema = new Schema<File>({
-  _id: { type: String, required: true },
-  description: { type: String, required: false, default: null },
-  type: { type: String, enum: Object.values(FileTypes), required: true },
-  size: { type: Number, required: true },
-  user_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
-});
+const fileSchema = new Schema<File>(
+  {
+    _id: { type: String, required: true },
+    description: { type: String, required: false, default: null },
+    type: { type: String, enum: Object.values(FileTypes), required: true },
+    size: { type: Number, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  },
+  { timestamps: true },
+);
 
 const FileModel = model<File>("File", fileSchema);
 
 export { FileModel };
+

--- a/src/models/refund.ts
+++ b/src/models/refund.ts
@@ -2,20 +2,24 @@ import { Schema, model, Types, Document } from "mongoose";
 
 interface Refund extends Document {
   title: string;
-  to_refund: number;
+  toRefund: number;
   done: boolean;
-  user_id: Types.ObjectId;
-  roommate_id: Types.ObjectId;
+  userId: Types.ObjectId;
+  roomateId: Types.ObjectId;
 }
 
-const refundSchema = new Schema<Refund>({
-  title: { type: String, required: true },
-  to_refund: { type: Number, required: true },
-  done: { type: Boolean, required: false, default: false },
-  user_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
-  roommate_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
-});
+const refundSchema = new Schema<Refund>(
+  {
+    title: { type: String, required: true },
+    toRefund: { type: Number, required: true },
+    done: { type: Boolean, required: false, default: false },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    roomateId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  },
+  { timestamps: true },
+);
 
 const RefundModel = model<Refund>("Refund", refundSchema);
 
 export default RefundModel;
+

--- a/src/models/rule.ts
+++ b/src/models/rule.ts
@@ -1,17 +1,24 @@
-import { Schema, model, Types, Document } from 'mongoose';
+import { Schema, model, Types, Document } from "mongoose";
 
 interface Rule extends Document {
   title: string;
   description: string;
-  accommodation_id: Types.ObjectId; 
-};
+  accommodationId: Types.ObjectId;
+}
 
-const ruleSchema = new Schema<Rule>({
-  title: { type: String, required: true },
-  description: { type: String, required: true },
-  accommodation_id: { type: Schema.Types.ObjectId, ref: 'Accommodation', required: true }
-})
+const ruleSchema = new Schema<Rule>(
+  {
+    title: { type: String, required: true },
+    description: { type: String, required: true },
+    accommodationId: {
+      type: Schema.Types.ObjectId,
+      ref: "Accommodation",
+      required: true,
+    },
+  },
+  { timestamps: true },
+);
 
-const RuleModel = model<Rule>('Rule', ruleSchema);
+const RuleModel = model<Rule>("Rule", ruleSchema);
 
 export default RuleModel;

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -14,7 +14,7 @@ const taskSchema = new Schema<Task>(
     name: { type: String, required: true },
     description: { type: String, required: false, default: null },
     weekly: { type: Boolean, required: true },
-    done: { type: Boolean, required: true },
+    done: { type: Boolean, required: false, default: false },
     userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
     accommodationId: {
       type: Schema.Types.ObjectId,

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -5,22 +5,25 @@ interface Task extends Document {
   description: string | null;
   weekly: boolean;
   done: boolean;
-  user_id: Types.ObjectId;
-  accommodation_id: Types.ObjectId;
+  userId: Types.ObjectId;
+  accommodationId: Types.ObjectId;
 }
 
-const taskSchema = new Schema<Task>({
-  name: { type: String, required: true },
-  description: { type: String, required: false, default: null },
-  weekly: { type: Boolean, required: true },
-  done: { type: Boolean, required: true },
-  user_id: { type: Schema.Types.ObjectId, ref: "User", required: true },
-  accommodation_id: {
-    type: Schema.Types.ObjectId,
-    ref: "Accommodation",
-    required: true,
+const taskSchema = new Schema<Task>(
+  {
+    name: { type: String, required: true },
+    description: { type: String, required: false, default: null },
+    weekly: { type: Boolean, required: true },
+    done: { type: Boolean, required: true },
+    userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+    accommodationId: {
+      type: Schema.Types.ObjectId,
+      ref: "Accommodation",
+      required: true,
+    },
   },
-});
+  { timestamps: true },
+);
 
 const TaskModel = model<Task>("Task", taskSchema);
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,38 +1,41 @@
 import { Schema, model, Types, Document } from "mongoose";
 
 interface User extends Document {
-  firstname: string;
-  lastname: string;
+  firstName: string;
+  lastName: string;
   username: string;
   password: string;
   age: number;
   description: string | null;
   email: string;
-  phone_number: string;
-  profile_picture_id: Types.ObjectId | null;
-  accommodation_id: Types.ObjectId | null;
+  phoneNumber: string;
+  profilePictureId: Types.ObjectId | null;
+  accommodationId: Types.ObjectId | null;
 }
 
-const userSchema = new Schema<User>({
-  firstname: { type: String, required: true },
-  lastname: { type: String, required: true },
-  username: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  age: { type: Number, required: true },
-  description: { type: String, required: false, default: null },
-  email: { type: String, required: true, unique: true },
-  phone_number: { type: String, required: true },
-  profile_picture_id: {
-    type: Schema.Types.ObjectId,
-    ref: "File",
-    required: false,
+const userSchema = new Schema<User>(
+  {
+    firstName: { type: String, required: true },
+    lastName: { type: String, required: true },
+    username: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    age: { type: Number, required: true },
+    description: { type: String, required: false, default: null },
+    email: { type: String, required: true, unique: true },
+    phoneNumber: { type: String, required: true },
+    profilePictureId: {
+      type: Schema.Types.ObjectId,
+      ref: "File",
+      required: false,
+    },
+    accommodationId: {
+      type: Schema.Types.ObjectId,
+      ref: "Accommodation",
+      required: false,
+    },
   },
-  accommodation_id: {
-    type: Schema.Types.ObjectId,
-    ref: "Accommodation",
-    required: false,
-  },
-});
+  { timestamps: true },
+);
 
 const UserModel = model<User>("User", userSchema);
 

--- a/src/test/integration/api-sanitize.test.ts
+++ b/src/test/integration/api-sanitize.test.ts
@@ -1,0 +1,33 @@
+import request from "supertest";
+import app from "../../app";
+
+describe("XSS sanitization Test", () => {
+  let taskId = "";
+
+  afterAll(async () => {
+    await request(app)
+      .delete(`/api/tasks/${taskId}`)
+      .catch(() => {});
+  });
+
+  test("POST /tasks should create a new task", async () => {
+    const taskData = {
+      name: "Sanitize Test",
+      description: "<script>alert('XSS')</script>",
+      weekly: true,
+      userId: "67ecf50fe1ec65f57a487989",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
+    };
+
+    const response = await request(app)
+      .post("/api/tasks")
+      .send(taskData)
+      .expect(201);
+
+    expect(response.body).toHaveProperty("message", "Ok");
+    expect(response.body.data).toHaveProperty("description", "");
+    taskId = response.body.data._id;
+  });
+});
+
+export default {};

--- a/src/test/integration/event.test.ts
+++ b/src/test/integration/event.test.ts
@@ -14,10 +14,10 @@ describe("Event API Integration Tests", () => {
     const eventData = {
       title: "Test Event",
       description: "This is a test event",
-      planned_date: "2023-12-01T10:00:00.000Z",
-      end_date: "2023-12-01T12:00:00.000Z",
-      user_id: "67ecf50fe1ec65f57a487989",
-      accommodation_id: "67e922f5f031d41cd1da4fe4",
+      plannedDate: "2023-12-01T10:00:00.000Z",
+      endDate: "2023-12-01T12:00:00.000Z",
+      userId: "67ecf50fe1ec65f57a487989",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
     };
 
     const response = await request(app)
@@ -34,10 +34,10 @@ describe("Event API Integration Tests", () => {
     const invalidEventData = {
       title: "",
       description: "This is a test event",
-      planned_date: "invalid-date",
-      end_date: "2023-12-01T12:00:00.000Z",
-      user_id: "invalid-user-id",
-      accommodation_id: "67e922f5f031d41cd1da4fe4",
+      plannedDate: "invalid-date",
+      endDate: "2023-12-01T12:00:00.000Z",
+      userId: "invalid-user-id",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
     };
 
     const response = await request(app)

--- a/src/test/integration/refund.test.ts
+++ b/src/test/integration/refund.test.ts
@@ -1,6 +1,5 @@
 import request from "supertest";
 import app from "../../app";
-import e from "express";
 
 describe("Refund API Integration Tests", () => {
   let refundId = "";
@@ -14,9 +13,9 @@ describe("Refund API Integration Tests", () => {
   test("POST /refunds should create a new refund", async () => {
     const refundData = {
       title: "Test Refund",
-      to_split: 200,
-      user_id: "67ecf50fe1ec65f57a487989",
-      roommate_ids: ["67e922f5f031d41cd1da4fe4"],
+      toSplit: 200,
+      userId: "67ecf50fe1ec65f57a487989",
+      roomateIds: ["67e922f5f031d41cd1da4fe4"],
     };
 
     const response = await request(app)
@@ -32,9 +31,9 @@ describe("Refund API Integration Tests", () => {
   test("POST /refunds should return 400 for invalid data", async () => {
     const invalidRefundData = {
       title: "",
-      to_split: -100,
-      user_id: "",
-      roommate_ids: [],
+      toSplit: -100,
+      userId: "",
+      roomateIds: [],
     };
 
     const response = await request(app)
@@ -60,8 +59,8 @@ describe("Refund API Integration Tests", () => {
 
   test("GET /refunds/filter should return refunds by filter", async () => {
     const params = {
-      to_refund_start: 99,
-      to_refund_end: 101,
+      toRefundStart: 99,
+      toRefundEnd: 101,
     };
 
     const response = await request(app)
@@ -76,7 +75,7 @@ describe("Refund API Integration Tests", () => {
   test("PUT /refunds/:id should update a refund by ID", async () => {
     const updatedData = {
       title: "Test Refund",
-      to_refund: 0,
+      toRefund: 0,
     };
 
     const response = await request(app)
@@ -86,7 +85,7 @@ describe("Refund API Integration Tests", () => {
 
     expect(response.body).toHaveProperty("message", "Ok");
     expect(response.body.data).toHaveProperty("_id", refundId);
-    expect(response.body.data).toHaveProperty("to_refund", 0);
+    expect(response.body.data).toHaveProperty("toRefund", 0);
   });
 
   test("DELETE /refunds/:id should delete a refund by ID", async () => {

--- a/src/test/integration/rule.test.ts
+++ b/src/test/integration/rule.test.ts
@@ -14,7 +14,7 @@ describe("Rule API Integration Tests", () => {
     const ruleData = {
       title: "Test Rule",
       description: "This is a test rule",
-      accommodation_id: "67e922f5f031d41cd1da4fe4",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
     };
 
     const response = await request(app)

--- a/src/test/integration/task.test.ts
+++ b/src/test/integration/task.test.ts
@@ -16,8 +16,8 @@ describe("Task API Integration Tests", () => {
       description: "This is a test task",
       weekly: true,
       done: false,
-      user_id: "67ecf50fe1ec65f57a487989",
-      accommodation_id: "67e922f5f031d41cd1da4fe4",
+      userId: "67ecf50fe1ec65f57a487989",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
     };
 
     const response = await request(app)
@@ -36,8 +36,8 @@ describe("Task API Integration Tests", () => {
       description: "This is a test task",
       weekly: "true",
       done: "false",
-      user_id: "01010001001001010101010",
-      accommodation_id: "0101010010001010101010",
+      userId: "01010001001001010101010",
+      accommodationId: "0101010010001010101010",
     };
 
     const response = await request(app)

--- a/src/test/integration/user.test.ts
+++ b/src/test/integration/user.test.ts
@@ -12,16 +12,16 @@ describe("User API Integration Tests", () => {
 
   test("POST /auth/register should create a new user", async () => {
     const userData = {
-      firstname: "John",
-      lastname: "Doe",
+      firstName: "John",
+      lastName: "Doe",
       username: "JOJOJO",
       password: "password1234",
       age: 30,
       description: "Test user",
       email: "jojojo@example.com",
-      phone_number: "1234567890",
-      profile_picture_id: "67e922f5f031d41cd1da4fe4",
-      accommodation_id: "67e922f5f031d41cd1da4fe4",
+      phoneNumber: "1234567890",
+      profilePictureId: "67e922f5f031d41cd1da4fe4",
+      accommodationId: "67e922f5f031d41cd1da4fe4",
     };
 
     const response = await request(app)
@@ -30,7 +30,7 @@ describe("User API Integration Tests", () => {
       .expect(201);
 
     expect(response.body).toHaveProperty("message", "Ok");
-    expect(response.body.data).toHaveProperty("firstname", "John");
+    expect(response.body.data).toHaveProperty("firstName", "John");
     userId = response.body.data._id;
   });
 
@@ -39,7 +39,7 @@ describe("User API Integration Tests", () => {
       age: 30,
       description: "Test user",
       email: "jojo@example.com",
-      phone_number: "1234567890",
+      phoneNumber: "1234567890",
     };
 
     const response = await request(app)
@@ -77,7 +77,7 @@ describe("User API Integration Tests", () => {
 
   test("PUT /users/:id should update a user by ID", async () => {
     const updatedData = {
-      firstname: "Jane",
+      firstName: "Jane",
       age: 28,
       description: "Updated test user",
     };
@@ -89,7 +89,7 @@ describe("User API Integration Tests", () => {
 
     expect(response.body).toHaveProperty("message", "Ok");
     expect(response.body.data).toHaveProperty("_id", userId);
-    expect(response.body.data).toHaveProperty("firstname", "Jane");
+    expect(response.body.data).toHaveProperty("firstName", "Jane");
   });
 
   test("DELETE /users/:id should delete a user by ID", async () => {


### PR DESCRIPTION
Tout d'abord, refactor des noms des champs car il y avait un mix snake_case et camelCase, j'ai tout mis en camelCase.

J'ai vu que le middleware de Mongo ne nettoye que les données NoSql avec "$" et "." et ne protège pas contre des script XSS envoyé en tant que string.

Dans cette PR j'ai donc ajouté 2 middlewares qui protègent la BDD contre les données contenant un script JS malveillant type XSS ("<script>alert()</script>"). Avec le custom middleware qui utilise sanitize-html, les données reçu pour les POST/PATCH sont nettoyées et s'il y a un script js, le champs est enregistré comme vide (ce qui peut créer des bad request, côté front il faudra nettoyé les données aussi). Le deuxième middleware, helmet, va mettre dans les headers HTTP de la protection contre les attaques XSS du côté frontend, ce qui assure une double protection XSS.

