### PR TITLE
fix: fix update user

### DIFF
--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -10,6 +10,7 @@ interface QueryParamsUsers {
     lastName?: { $regex: string; $options: string };
     username?: { $regex: string; $options: string };
   }[];
+  accommodationId?: mongoose.Types.ObjectId;
 }
 
 const getAllUsers = async (req: Request, res: Response): Promise<any> => {
@@ -149,7 +150,7 @@ const deleteUserById = async (req: Request, res: Response): Promise<any> => {
 
 const filterUsers = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { name } = req.query;
+    const { name, accommodationId } = req.query;
 
     const params: QueryParamsUsers = {};
 
@@ -160,6 +161,13 @@ const filterUsers = async (req: Request, res: Response): Promise<any> => {
         { lastName: regex },
         { username: regex },
       ];
+    }
+
+    if (accommodationId && typeof accommodationId === "string") {
+      if (!mongoose.Types.ObjectId.isValid(accommodationId)) {
+        return res.status(400).json({ message: "Bad request" });
+      }
+      params.accommodationId = new mongoose.Types.ObjectId(accommodationId);
     }
 
     const users = await User.find(params).select("-password");

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -63,14 +63,14 @@ const updateUserById = async (req: Request, res: Response): Promise<any> => {
 
     if (username) {
       const existingUsername = await User.findOne({ username });
-      if (existingUsername) {
+      if (existingUsername && existingUsername._id.toString() !== id) {
         return res.status(409).json({ message: "Username already taken" });
       }
     }
 
     if (email) {
       const existingEmail = await User.findOne({ email });
-      if (existingEmail) {
+      if (existingEmail && existingEmail._id.toString() !== id) {
         return res.status(409).json({ message: "Username already taken" });
       }
     }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -7,6 +7,7 @@ router.get("/", userCtrl.getAllUsers);
 router.get("/filter", userCtrl.filterUsers);
 router.get("/:id", userCtrl.getUserById);
 router.patch("/:id", userCtrl.updateUserById);
+router.patch("/password/:id", userCtrl.updatePasswordById);
 router.delete("/:id", userCtrl.deleteUserById);
 
 export default router;


### PR DESCRIPTION
Petit fix du update user. En gros si un utilisateur entre le même username et email qu'il a déjà (données qu'il aura par défaut dans le form), ça check pas si ces valeurs là lui appartient. Donc message d'erreur username/email existe déjà alors que ça lui appartient.

J'ai aussi séparé le update du mdp de updateUserById. En général on sépare le form de modification d'un mdp du form update user. C'est plus un truc de sécurité. Ce form demandera donc le mdp actuel et le nouveau mdp (avec un champs de confirmation dans le front).