### PR TITLE
Feature/add permissions management to requests

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,5 @@
 API_PORT="8080"
-MONGODB_URI="mongodb+srv://dev:<db_password>@coabi.mwsln.mongodb.net/?retryWrites=true&w=majority&appName=COABI"
+MONGODB_URI="mongodb+srv://dev:<db_password>@coabi.mwsln.mongodb.net/<collection>?retryWrites=true&w=majority&appName=COABI"
 ACCESS_TOKEN_SECRET="AccessTokenSecret"
 REFRESH_TOKEN_SECRET="RefreshTokenSecret"
 FRONTEND_BASE_URL="http://localhost:3000"

--- a/server.ts
+++ b/server.ts
@@ -10,3 +10,8 @@ const PORT: string | number = process.env.API_PORT || 8080;
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);
 });
+
+// uncomment for android testing purposes
+// app.listen(8080, '0.0.0.0', () => {
+//   console.log(`Server is running on http://0.0.0.0:${PORT}`);
+// });

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -1,6 +1,7 @@
 import Task from "../models/task";
 import { Request, Response } from "express";
 import mongoose from "mongoose";
+import { hasAccessToAccommodation } from "../utils/auth/accommodation";
 
 interface QueryParamsTasks {
   name?: {
@@ -10,10 +11,15 @@ interface QueryParamsTasks {
   weekly?: boolean;
   done?: boolean;
   userId?: string;
+  accommodationId?: mongoose.Types.ObjectId;
 }
 
 const getAllTasks = async (req: Request, res: Response): Promise<any> => {
   try {
+    const role = req.role;
+    if (role && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
     const tasks = await Task.find();
     return res.status(200).json(tasks);
   } catch (error: any) {
@@ -25,13 +31,17 @@ const getAllTasks = async (req: Request, res: Response): Promise<any> => {
 
 const createTask = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { name, description, weekly, done, userId, accommodationId } =
-      req.body;
+    const { name, description, userId, accommodationId } = req.body;
+    const role = req.role;
+    const userAccommodationId = req.accommodationId;
+
+    if (!hasAccessToAccommodation(role, userAccommodationId, accommodationId)) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
 
     const newTask = new Task({
       name,
       description,
-      weekly,
       userId,
       accommodationId,
     });
@@ -51,6 +61,8 @@ const createTask = async (req: Request, res: Response): Promise<any> => {
 const getTaskById = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
+    const role = req.role;
+    const userAccommodationId = req.accommodationId;
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(400).json({ message: "Bad request" });
@@ -60,6 +72,16 @@ const getTaskById = async (req: Request, res: Response): Promise<any> => {
 
     if (!task) {
       return res.status(404).json({ message: "Not found" });
+    }
+
+    if (
+      !hasAccessToAccommodation(
+        role,
+        userAccommodationId,
+        task.accommodationId.toString(),
+      )
+    ) {
+      return res.status(403).json({ message: "Forbidden" });
     }
 
     return res.status(200).json(task);
@@ -72,21 +94,33 @@ const getTaskById = async (req: Request, res: Response): Promise<any> => {
 
 const updateTaskById = async (req: Request, res: Response): Promise<any> => {
   try {
+    const updateData = req.body;
     const { id } = req.params;
+    const role = req.role;
+    const userAccommodationId = req.accommodationId;
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(400).json({ message: "Bad request" });
     }
 
-    const task = await Task.findByIdAndUpdate(
-      id,
-      { ...req.body },
-      { new: true, runValidators: true },
-    );
+    const task = await Task.findById(id);
 
     if (!task) {
       return res.status(404).json({ message: "Not found" });
     }
+
+    if (
+      !hasAccessToAccommodation(
+        role,
+        userAccommodationId,
+        task.accommodationId.toString(),
+      )
+    ) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    task.set(updateData);
+    await task.save();
 
     return res.status(200).json(task);
   } catch (error: any) {
@@ -102,16 +136,30 @@ const updateTaskById = async (req: Request, res: Response): Promise<any> => {
 const deleteTaskById = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
+    const role = req.role;
+    const userAccommodationId = req.accommodationId;
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(400).json({ message: "Bad request" });
     }
 
-    const task = await Task.findByIdAndDelete(id);
+    const task = await Task.findById(id);
 
     if (!task) {
       return res.status(404).json({ message: "Not found" });
     }
+
+    if (
+      !hasAccessToAccommodation(
+        role,
+        userAccommodationId,
+        task.accommodationId.toString(),
+      )
+    ) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    await task.deleteOne();
 
     return res.sendStatus(204);
   } catch (error: any) {
@@ -124,6 +172,8 @@ const deleteTaskById = async (req: Request, res: Response): Promise<any> => {
 const filterTasks = async (req: Request, res: Response): Promise<any> => {
   try {
     const { name, weekly, done, userId } = req.query;
+    const role = req.role;
+    const userAccommodationId = req.accommodationId;
 
     const params: QueryParamsTasks = {};
 
@@ -141,6 +191,10 @@ const filterTasks = async (req: Request, res: Response): Promise<any> => {
 
     if (userId) {
       params.userId = userId as string;
+    }
+
+    if (role && role !== "admin" && userAccommodationId) {
+      params.accommodationId = new mongoose.Types.ObjectId(userAccommodationId);
     }
 
     const events = await Task.find(params);

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -3,7 +3,9 @@ import { JwtPayload } from "jsonwebtoken";
 declare global {
   namespace Express {
     interface Request {
-      user?: string | JwtPayload;
+      userId?: string | JwtPayload;
+      accommodationId?: string | null;
+      role: "user" | "moderator" | "admin";
     }
   }
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -29,8 +29,11 @@ const authMiddleware = async (
 
   try {
     const decoded = verifyAccessToken(token);
-    req.userId = decoded;
-    const user = await User.findById(decoded);
+    if (!decoded || typeof decoded !== "object" || !("id" in decoded)) {
+      return res.status(401).json({ message: "Invalid token" });
+    }
+    req.userId = decoded.id;
+    const user = await User.findById(decoded.id);
     if (!user) {
       return res.status(404).json({ message: "Not found" });
     }
@@ -38,7 +41,7 @@ const authMiddleware = async (
     req.role = user.role;
     next();
   } catch (error: any) {
-    return res.status(401).json({ message: "Invalid or expired token" });
+    return res.status(401).json({ message: "Invalid or expired token", error });
   }
 };
 

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -19,7 +19,7 @@ const taskSchema = new Schema<Task>(
       default: null,
       maxlength: 200,
     },
-    weekly: { type: Boolean, required: true },
+    weekly: { type: Boolean, required: false, default: false }, // ne pas utiliser pour l'instant
     done: { type: Boolean, required: false, default: false },
     userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
     accommodationId: {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -10,6 +10,7 @@ interface User extends Document {
   description: string | null;
   email: string;
   phoneNumber: string | null;
+  role: "user" | "moderator" | "admin";
   profilePictureId: Types.ObjectId | null;
   accommodationId: Types.ObjectId | null;
 }
@@ -40,6 +41,12 @@ const userSchema = new Schema<User>(
       unique: false,
       default: null,
       maxlength: 15,
+    },
+    role: {
+      type: String,
+      required: false,
+      enum: ["user", "moderator", "admin"],
+      default: "user",
     },
     profilePictureId: {
       type: Schema.Types.ObjectId,

--- a/src/test/integration/task.test.ts
+++ b/src/test/integration/task.test.ts
@@ -14,8 +14,6 @@ describe("Task API Integration Tests", () => {
     const taskData = {
       name: "Test Task",
       description: "This is a test task",
-      weekly: true,
-      done: false,
       userId: "67ecf50fe1ec65f57a487989",
       accommodationId: "67e922f5f031d41cd1da4fe4",
     };

--- a/src/utils/auth/accommodation.ts
+++ b/src/utils/auth/accommodation.ts
@@ -1,0 +1,33 @@
+type Role = "user" | "moderator" | "admin" | undefined;
+
+export const hasAccessToAccommodation = (
+  role: Role,
+  userAccommodationId: string | null | undefined,
+  requestAccommodationId: string,
+): boolean => {
+  if (role === "admin") {
+    return true;
+  }
+
+  if (role && userAccommodationId) {
+    return userAccommodationId === requestAccommodationId;
+  }
+
+  return true;
+};
+
+export const canModifyAccommodation = (
+  role: Role,
+  userAccommodationId: string | null | undefined,
+  requestAccommodationId: string,
+): boolean => {
+  if (role === "admin") {
+    return true;
+  }
+
+  if (role && role === "moderator" && userAccommodationId) {
+    return userAccommodationId === requestAccommodationId;
+  }
+
+  return true;
+};


### PR DESCRIPTION
(En draft, en attendant que la branche du dessous soit validé et merge)

J'ai ajouté le champs "role" dans user qui est soit un user normal, soit un modérateur (créateur d'une colocation), soit un admin qui a tous les privilèges. 

-Les utilisateurs non "admin" peuvent seulement faire des requêtes à l'intérieur de leur colocation. C'est-à-dire ils ne peuvent pas chopper ou modifier des données dans une autre colocation. 

-Le modérateur a, en plus qu'un user normal, la possibilité de modifié une colocation (pour l'instant).

J'avais essayé tout d'abord de faire toute cette gestion dans un middleware mais c'est trop complexe. Du coup j'ai opté pour une autre solution. J'ai ajouté dans request les champs "accommodationId" et "role" depuis le middleware auth. Lorsqu'un access token est décodé, je choppe les info du user avec son id et je mets ce qui est voulu dans req.accommodationId et req.role.
Grâce à ces données, je peux obtenir dans toutes les requêtes la colocation du user ainsi que son rôle. Toute la logique c'est ensuite ajouté dans tous les controllers.