### PR TITLE
fix: add check for get methods when accommodationId is null

### DIFF
--- a/src/controllers/refund.ts
+++ b/src/controllers/refund.ts
@@ -57,11 +57,22 @@ const checkRefundAccess = async (
 const getAllRefunds = async (req: Request, res: Response): Promise<any> => {
   try {
     const { role, accommodationId: userAccommodationId } = req;
+    const { adminUI } = req.query;
 
-    const params =
-      !testEnv && role !== "admin" && userAccommodationId
-        ? { accommodationId: new mongoose.Types.ObjectId(userAccommodationId) }
-        : {};
+    if (!testEnv && !userAccommodationId && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    let params: any = {};
+
+    if (role !== "admin" && adminUI !== "true") {
+      if (userAccommodationId) {
+        params.accommodationId = new mongoose.Types.ObjectId(
+          userAccommodationId,
+        );
+      }
+    }
+
     const refunds = await Refund.find(params);
     return res.json(refunds);
   } catch (error: any) {
@@ -235,6 +246,10 @@ const filterRefunds = async (req: Request, res: Response): Promise<any> => {
   try {
     const { title, toRefundStart, toRefundEnd, roommateId } = req.query;
     const { role, accommodationId: userAccommodationId } = req;
+
+    if (!testEnv && !userAccommodationId && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
 
     const params: QueryParamsRefunds = {};
 

--- a/src/controllers/rule.ts
+++ b/src/controllers/rule.ts
@@ -7,11 +7,22 @@ import { testEnv } from "../utils/env";
 const getAllRules = async (req: Request, res: Response): Promise<any> => {
   try {
     const { role, accommodationId: userAccommodationId } = req;
+    const { adminUI } = req.query;
 
-    const params =
-      !testEnv && role !== "admin" && userAccommodationId
-        ? { accommodationId: new mongoose.Types.ObjectId(userAccommodationId) }
-        : {};
+    if (!testEnv && !userAccommodationId && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    let params: any = {};
+
+    if (role !== "admin" && adminUI !== "true") {
+      if (userAccommodationId) {
+        params.accommodationId = new mongoose.Types.ObjectId(
+          userAccommodationId,
+        );
+      }
+    }
+
     const rules = await Rule.find(params);
     return res.status(200).json(rules);
   } catch (error: any) {

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -18,11 +18,22 @@ interface QueryParamsTasks {
 const getAllTasks = async (req: Request, res: Response): Promise<any> => {
   try {
     const { role, accommodationId: userAccommodationId } = req;
+    const { adminUI } = req.query;
 
-    const params =
-      !testEnv && role !== "admin" && userAccommodationId
-        ? { accommodationId: new mongoose.Types.ObjectId(userAccommodationId) }
-        : {};
+    if (!testEnv && !userAccommodationId && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    let params: any = {};
+
+    if (role !== "admin" && adminUI !== "true") {
+      if (userAccommodationId) {
+        params.accommodationId = new mongoose.Types.ObjectId(
+          userAccommodationId,
+        );
+      }
+    }
+
     const tasks = await Task.find(params);
     return res.status(200).json(tasks);
   } catch (error: any) {
@@ -172,6 +183,10 @@ const filterTasks = async (req: Request, res: Response): Promise<any> => {
   try {
     const { name, weekly, done, userId } = req.query;
     const { role, accommodationId: userAccommodationId } = req;
+
+    if (!testEnv && !userAccommodationId && role !== "admin") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
 
     const params: QueryParamsTasks = {};
 


### PR DESCRIPTION
J'ai oublié d'ajouter le check de si l'accommodation de l'utilisateur est null et s'il n'est pas admin. Du coup, un utilisateur qui n'a pas d'accommodation peut chopper tous les données avec les méthodes get all.

J'ai aussi ajouté un paramètre adminUI qui si "true" permettra d'obtenir tous les utilisateurs. Car si t'es admin mais que tu utilises l'interface utilisateurs, tu veux pas forcément obtenir toutes les données d'un modèle, en dehors de sa colocation.