### PR TITLE
feat: add Docker Compose deployment workflow for Azure VM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Déploiement Docker Compose sur Azure VM
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Connexion SSH et déploiement
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.AZURE_VM_IP }}
+          username: ${{ secrets.AZURE_VM_USER }}
+          key: ${{ secrets.AZURE_VM_SSH_KEY }}
+          script: |
+            cd coabi-backend
+            git pull origin main
+            docker compose down || true
+            docker compose up --build -d


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for deploying a Docker Compose application to an Azure Virtual Machine. The workflow triggers on pushes to the `main` branch and uses the `appleboy/ssh-action` to connect to the VM and execute deployment commands.

Deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R22): Created a new workflow named "Déploiement Docker Compose sur Azure VM" that automates the deployment process by pulling the latest changes, stopping any running containers, and rebuilding and starting the application using Docker Compose.