### PR TITLE
feat: add deployment workflows for Azure VM (dev and prod)

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -1,0 +1,24 @@
+name: Déploiement sur Azure VM - Développement
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Connexion SSH et déploiement
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.AZURE_VM_IP }}
+          username: ${{ secrets.AZURE_VM_USER }}
+          key: ${{ secrets.AZURE_VM_SSH_KEY }}
+          script: |
+            cd ~ 
+            cd coabi/api/dev
+            git pull origin dev
+            docker compose down || true
+            docker compose up --build -d

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -1,4 +1,4 @@
-name: Déploiement Docker Compose sur Azure VM
+name: Déploiement sur Azure VM - Production
 
 on:
   push:
@@ -17,7 +17,8 @@ jobs:
           username: ${{ secrets.AZURE_VM_USER }}
           key: ${{ secrets.AZURE_VM_SSH_KEY }}
           script: |
-            cd coabi-backend
+            cd ~ 
+            cd coabi/api/prod
             git pull origin main
             docker compose down || true
             docker compose up --build -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '3.8'
+version: "3.8"
 
 services:
   backend:
     build: .
     container_name: coabi-backend
     ports:
-      - "8080:8080"
+      - ${DOCKER_API_PORT}:8080
     environment:
       - API_PORT=${API_PORT}
       - MONGODB_URI=${MONGODB_URI}


### PR DESCRIPTION
This pull request introduces updates to the deployment workflows and the `docker-compose.yml` file to improve deployment processes and enhance configurability. The most important changes include creating a new workflow for development deployment, renaming and updating the production deployment workflow, and making the Docker Compose configuration more dynamic by using environment variables.

### Deployment workflow updates:

* [`.github/workflows/deploy-to-dev.yml`](diffhunk://#diff-23bd86d904c522eb4334eb9c5b84932cede5343b449c9fe46f930954dcf5a05bR1-R24): Added a new GitHub Actions workflow for deploying the development environment to an Azure VM. This workflow triggers on pushes to the `dev` branch and includes steps for pulling the latest changes, stopping existing containers, and rebuilding and starting the Docker Compose services.

* [`.github/workflows/deploy-to-prod.yml`](diffhunk://#diff-97b26daa74628ee6d0d5163fdefa7757fb101d353ff1f817ee840bf518536afeL1-R1): Renamed the production deployment workflow file from `deploy.yml` to `deploy-to-prod.yml` and updated the workflow name to clarify its purpose.

* [`.github/workflows/deploy-to-prod.yml`](diffhunk://#diff-97b26daa74628ee6d0d5163fdefa7757fb101d353ff1f817ee840bf518536afeL20-R21): Updated the production deployment workflow to use the correct directory structure (`coabi/api/prod`) for the production environment.

### Docker Compose configuration updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R8): Made the port mapping for the `backend` service dynamic by replacing the hardcoded `8080` with the `DOCKER_API_PORT` environment variable. This change allows for more flexible configuration of the exposed port.